### PR TITLE
Add support for custom types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin</groupId>
     <artifactId>vcf-handsontable-flow</artifactId>
-    <version>3.0.2</version>
+    <version>3.1.0</version>
     <name>Handsontable for Flow</name>
     <description>Integration of Hansontable for Vaadin platform</description>
 
@@ -69,6 +69,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin</groupId>
     <artifactId>vcf-handsontable-flow</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <name>Handsontable for Flow</name>
     <description>Integration of Hansontable for Vaadin platform</description>
 

--- a/src/main/resources/META-INF/resources/frontend/handsontable/handsontableConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/handsontable/handsontableConnector.js
@@ -1,42 +1,11 @@
 import Handsontable from "./dist/handsontable.full.min.js";
 
-function handsontableRenderer(instance, td, row, col, prop, value, cellProperties) {
-  var renderer;
+const DEFAULT_RENDERER = Handsontable.renderers.TextRenderer;
 
-  switch (cellProperties.type) {
-    case "autocomplete":
-      renderer = Handsontable.renderers.AutocompleteRenderer;
-      break;
-    case "base":
-      renderer = Handsontable.renderers.BaseRenderer;
-      break;
-    case "checkbox":
-      renderer = Handsontable.renderers.CheckboxRenderer;
-      break;
-    case "date":
-      renderer = Handsontable.renderers.DateRenderer;
-      break;
-    case "dropdown":
-      renderer = Handsontable.renderers.DropdownRenderer;
-      break;
-    case "html":
-      renderer = Handsontable.renderers.HtmlRenderer;
-      break;
-    case "numeric":
-      renderer = Handsontable.renderers.NumericRenderer;
-      break;
-    case "password":
-      renderer = Handsontable.renderers.PasswordRenderer;
-      break;
-    case "text":
-      renderer = Handsontable.renderers.TextRenderer;
-      break;
-    case "time":
-      renderer = Handsontable.renderers.TimeRenderer;
-      break;
-    default:
-      renderer = Handsontable.renderers.TextRenderer;
-  }
+function handsontableRenderer(instance, td, row, col, prop, value, cellProperties) {
+
+  let cellType = Handsontable.cellTypes.getCellType(cellProperties.type);
+  let renderer = (cellType && cellType.renderer) ? cellType.renderer : DEFAULT_RENDERER;
 
   renderer.apply(this, arguments);
 
@@ -47,7 +16,7 @@ function handsontableRenderer(instance, td, row, col, prop, value, cellPropertie
     td.style.fontStyle = 'italic';
   }
 
-  var textDecoration = '';
+  let textDecoration = '';
   if (cellProperties.strikethrough) {
     textDecoration = 'line-through ';
   }
@@ -360,3 +329,4 @@ i18n.set('en-US')`Border`
 
 // ==============================
 window.createHandsontable = createHandsontable;
+window.Handsontable = Handsontable;

--- a/src/main/resources/META-INF/resources/frontend/handsontable/handsontableConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/handsontable/handsontableConnector.js
@@ -4,7 +4,8 @@ const DEFAULT_RENDERER = Handsontable.renderers.TextRenderer;
 
 function handsontableRenderer(instance, td, row, col, prop, value, cellProperties) {
 
-  let cellType = Handsontable.cellTypes.getCellType(cellProperties.type);
+  let cellType = Handsontable.cellTypes.hasOwnProperty(cellProperties.type) ?
+      Handsontable.cellTypes.getCellType(cellProperties.type) : null;
   let renderer = (cellType && cellType.renderer) ? cellType.renderer : DEFAULT_RENDERER;
 
   renderer.apply(this, arguments);

--- a/src/test/java/com/vaadin/componentfactory/handsontable/CustomTypeView.java
+++ b/src/test/java/com/vaadin/componentfactory/handsontable/CustomTypeView.java
@@ -1,0 +1,48 @@
+package com.vaadin.componentfactory.handsontable;
+
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.router.Route;
+
+import javax.json.JsonArray;
+import java.util.ArrayList;
+import java.util.List;
+
+@Route("custom-type")
+@JavaScript("./handsontable/handsontableConnector.js")
+@JavaScript("./password-type.js")
+public class CustomTypeView extends AbstractDemoView {
+
+    private static final String[] HEADERS = {"Username", "Password"};
+    private static final String SAMPLE_JSON_DATA =
+            "[[\"JohnDoe\",\"hunter1\"]," +
+            "[\"admin\",\"password\"]," +
+            "[\"zZ_pWn3r^_Zz\",\"iliketrains\"]," +
+            "[\"user_2323\",\"abc123\"]]]" ;
+
+    public CustomTypeView() {
+        add(new H1("Custom Type"));
+
+        JsonArray data = createJsonArray(SAMPLE_JSON_DATA);
+        Handsontable handsontable = new Handsontable(data);
+        handsontable.setId("hot1");
+
+        Settings settings = new Settings();
+
+        List<Column> columns = new ArrayList<>();
+        Column column = new Column();
+        column.setReadOnly(true);
+        columns.add(column);
+
+        column = new Column();
+        column.setType("password");
+        columns.add(column);
+
+        settings.setColumns(columns);
+        settings.setColHeaders(HEADERS);
+        settings.setRowHeaders(false);
+        handsontable.setSettings(settings);
+
+        add(handsontable);
+    }
+}

--- a/src/test/java/com/vaadin/componentfactory/handsontable/MainView.java
+++ b/src/test/java/com/vaadin/componentfactory/handsontable/MainView.java
@@ -16,5 +16,6 @@ public class MainView extends VerticalLayout {
         add(new RouterLink("Formula", FormulaDemoView.class));
         add(new RouterLink("Empty Table", EmptyTableView.class));
         add(new RouterLink("Big Table", BigTableDemoView.class));
+        add(new RouterLink("Custom Type", CustomTypeView.class));
     }
 }

--- a/src/test/resources/META-INF/resources/frontend/password-type.js
+++ b/src/test/resources/META-INF/resources/frontend/password-type.js
@@ -1,0 +1,54 @@
+/**
+ * @param {Object} instance Handsontable instance
+ * @param {Element} td Table cell where to render
+ * @param {Number} row
+ * @param {Number} col
+ * @param {String|Number} prop Row object property name
+ * @param value Value to render (remember to escape unsafe HTML before inserting to DOM!)
+ * @param {Object} cellProperties Cell properties (shared by cell renderer and editor)
+ */
+function passwordRenderer(instance, td, row, col, prop, value, cellProperties, ...args) {
+    if (cellProperties.valid !== false) {
+        const displayValue = value ? `${String(value).substring(0, 2)}***` : '';
+        td.innerHTML = `<span style='color: red'>${displayValue}</span>`
+    } else {
+        td.innerHTML = `ERROR`;
+    }
+}
+
+/**
+ * @param {*} value - Value of edited cell
+ * @param {Function} callback - Callback called with validation result
+ */
+function passwordValidator(value, callback) {
+    const valid = Boolean(value && String(value).length > 5);
+    callback(valid);
+}
+
+class PasswordEditor extends Handsontable.editors.TextEditor {
+    createElements() {
+        super.createElements();
+
+        this.TEXTAREA = this.hot.rootDocument.createElement('input');
+        this.TEXTAREA.setAttribute('type', 'password');
+        this.TEXTAREA.className = 'handsontableInput';
+        this.TEXTAREA.setAttribute('data-hot-input', ''); // Makes the element recognizable by HOT as its own component's element.
+        this.textareaStyle = this.TEXTAREA.style;
+        this.textareaStyle.width = 0;
+        this.textareaStyle.height = 0;
+
+        Handsontable.dom.empty(this.TEXTAREA_PARENT);
+        this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+    }
+}
+
+Handsontable.cellTypes.registerCellType('password', {
+    renderer: passwordRenderer,
+    editor: PasswordEditor,
+    validator: passwordValidator,
+    // You can add additional options to the cell type based on Handsontable settings
+    className: 'password-cell',
+    allowInvalid: true,
+    // Or you can add custom properties which will be accessible in `cellProperties`
+    editStatus: 'unedited',
+});


### PR DESCRIPTION
A couple of issues solved.

1. Handsontable is not available in a global context. I now export it with `window.Handsontable = Handsontable;` at the end of the `handsontableConnector.js`.

To ensure it is imported before adding new types, one must import the connector before importing any script that adds types, using `@JavaScript("./handsontable/handsontableConnector.js")`.

This is not optimal, but at least this way we ensure that it is imported, and that the _correct_ version is imported.

2. This integration sets the renderer of every column to a custom `handsontableRenderer`, in order to support bold/italic/strikethrough/underline/border settings.

It first delegates to the original renderer, but the options were hard-coded. Now it looks up the renderer from the type, allowing for custom types to define custom renderers.

